### PR TITLE
Fixed UnboundLocalError when building checkbox lists

### DIFF
--- a/sucuri/files.py
+++ b/sucuri/files.py
@@ -162,7 +162,7 @@ def _transform( text, obj=None ):
                 result += line
             return [result, "ul"]
 
-    elif len(params) == 2:
+        elif len(params) == 2:
             result = ""
             newresult = []
             textblock = "for value in obj['" + params[0] + "']:\n"


### PR DESCRIPTION
An UnboundLocalError was being raised because of incorrect indentation when creating lists of checkboxes. No necessary changes to README or tests.
Issue: #33 