### PR TITLE
fix(cli): add script directory to sys.path before running app with serve

### DIFF
--- a/sucuri/cli.py
+++ b/sucuri/cli.py
@@ -71,6 +71,10 @@ def serve(app_file, port, host, public):
         os.environ['SUCURI_HOST'] = host
     if public:
         os.environ['SUCURI_PUBLIC'] = '1'
+    # Ensure the script's directory is on sys.path so local modules are importable
+    script_dir = os.path.dirname(os.path.abspath(app_file))
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
     runpy.run_path(app_file, run_name='__main__')
 
 


### PR DESCRIPTION
runpy.run_path inserts the file path itself (e.g. main.py) into sys.path, not the parent directory. Local modules in the same folder as the app file (e.g. db.py, models/, repositories/) were not importable when running sucuri serve from a different working directory.